### PR TITLE
Reset version numbers to wip

### DIFF
--- a/code/API_definitions/kyc-tenure.yaml
+++ b/code/API_definitions/kyc-tenure.yaml
@@ -84,7 +84,7 @@ info:
 
     (FAQs will be added in a later version of the documentation)
 
-  version: 0.1.0-rc.1
+  version: wip
   x-camara-commonalities: 0.5
   license:
     name: Apache 2.0
@@ -95,7 +95,7 @@ externalDocs:
   url: https://github.com/camaraproject/Tenure
 
 servers:
-  - url: "{apiRoot}/kyc-tenure/v0.1rc1"
+  - url: "{apiRoot}/kyc-tenure/vwip"
     variables:
       apiRoot:
         default: https://localhost:9091

--- a/code/Test_definitions/kyc-tenure.feature
+++ b/code/Test_definitions/kyc-tenure.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Tenure API, v0.1.0-rc.1 - Operation check-tenure
+Feature: CAMARA Tenure API, vwip - Operation check-tenure
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -6,11 +6,11 @@ Feature: CAMARA Tenure API, v0.1.0-rc.1 - Operation check-tenure
     # Testing assets:
     # * A mobile line identified by its phone number "phoneNumber"
     #
-    # References to OAS spec schemas refer to schemas specifies in kyc-tenure.yaml, version 0.1.0-rc.1
+    # References to OAS spec schemas refer to schemas specifies in kyc-tenure.yaml, version wip
 
     Background: Common checkTenure setup
         Given an environment at "apiRoot"
-        And the resource "/kyc-tenure/v0.1-rc1/check-tenure"
+        And the resource "/kyc-tenure/vwip/check-tenure"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
Resets version numbers to wip to allow "version independent" changes before next release (0.1.0 or 0.1.0-rc.2)

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # N/A

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Reset version numbers to wip
```

#### Additional documentation 
None