### PR TITLE
Reset version numbers to wip following Spring25 meta-release

### DIFF
--- a/code/API_definitions/kyc-tenure.yaml
+++ b/code/API_definitions/kyc-tenure.yaml
@@ -84,7 +84,7 @@ info:
 
     (FAQs will be added in a later version of the documentation)
 
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.5
   license:
     name: Apache 2.0
@@ -95,7 +95,7 @@ externalDocs:
   url: https://github.com/camaraproject/Tenure
 
 servers:
-  - url: "{apiRoot}/kyc-tenure/v0.1"
+  - url: "{apiRoot}/kyc-tenure/vwip"
     variables:
       apiRoot:
         default: https://localhost:9091

--- a/code/Test_definitions/kyc-tenure.feature
+++ b/code/Test_definitions/kyc-tenure.feature
@@ -1,4 +1,4 @@
-Feature: CAMARA Tenure API, v0.1.0 - Operation checkTenure
+Feature: CAMARA Tenure API, vwip - Operation checkTenure
     # Input to be provided by the implementation to the tester
     #
     # Implementation indications:
@@ -10,7 +10,7 @@ Feature: CAMARA Tenure API, v0.1.0 - Operation checkTenure
 
     Background: Common checkTenure setup
         Given an environment at "apiRoot"
-        And the resource "/kyc-tenure/v0.1/check-tenure"
+        And the resource "/kyc-tenure/vwip/check-tenure"
         And the header "Content-Type" is set to "application/json"
         And the header "Authorization" is set to a valid access token
         And the header "x-correlator" is set to a UUID value


### PR DESCRIPTION
#### What type of PR is this?
* subproject management

#### What this PR does / why we need it:
Version numbers need to be reset to `wip` following the Spring25 meta-release

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #34 

#### Special notes for reviewers:
Standard chore following a meta-release

#### Changelog input

```
 release-note
 - Reset version numbers to wip following Spring25 meta-release
```

#### Additional documentation 
None