### PR TITLE
fix/contract-type-line-break

### DIFF
--- a/code/API_definitions/kyc-tenure.yaml
+++ b/code/API_definitions/kyc-tenure.yaml
@@ -361,6 +361,7 @@ components:
             - `PAYG` - prepaid (pay-as-you-go) account
             - `PAYM` - contract account
             - `Business` - Business (enterprise) account
+            
             This attribute may be omitted from the response set if the information is not available
           example: "PAYM"
           type: string


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* bug
* correction


#### What this PR does / why we need it:
Fix line break in `contractType` property to avoid confusion with optional value.

Original format:

![image](https://github.com/user-attachments/assets/b2ccd671-2283-4522-9b55-e81f30776d9d)

Fixed:
![image](https://github.com/user-attachments/assets/7c85ce12-3297-4639-9e41-5fb56d2ee69e)





#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #36
