### PR TITLE
Add text on undocumented errors to OAS definition 

### DIFF
--- a/code/API_definitions/kyc-tenure.yaml
+++ b/code/API_definitions/kyc-tenure.yaml
@@ -54,7 +54,13 @@ info:
 
     If the API consumer has a valid access token that does not have the required scope to obtain tenure information for the specified network subscription, then a `403 PERMISSION_DENIED` error is returned.
 
-    Other errors may be returned as specified in the example responses below.
+    ### Additional CAMARA error responses
+
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
+
+    As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 
     # Identifying the phone number from the access token
 


### PR DESCRIPTION
#### What type of PR is this?
* documentation

#### What this PR does / why we need it:
Adds mandatory text on undocumented errors to the OAS info.description section as defined [here](https://github.com/camaraproject/Commonalities/blob/main/documentation/CAMARA-API-Design-Guide.md#33-error-responses---mandatory-template-for-infodescription-in-camara-api-specs).

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #41 

#### Special notes for reviewers:
None

#### Changelog input

```
 release-note
 - Add text on undocumented errors to OAS definition 
```

#### Additional documentation 
None